### PR TITLE
Prepare 3.10.1-dev.0002

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
+# Unofficial, unaffiliated and unassociated fork of https://github.com/davemorrissey/subsampling-scale-image-view for internal use in Cryptomator for Android.
+
+> [!IMPORTANT]  
+> This project is provided under the terms of the [Apache License, Version 2.0;](LICENSE) while it is made available to the public,
+> it is important to note that this repository is **not intended for public use** and therefore **no support** is provided whatsoever.
+>
+> For a project designed for use by the public, please refer to the [original repository.](https://github.com/davemorrissey/subsampling-scale-image-view)
+>
+> An excerpt from the README of the original project is reproduced below for your convenience and to provide proper attribution.  
+> This project is not affiliated, associated, endorsed by, or in any way officially connected with David Morrissey, or any of their affiliates.
+
+---
+
+# Excerpt from the original README
+
 Subsampling Scale Image View
 ===========================
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,16 @@
+/*
+ * ** Notice of Modification **
+ *
+ * This file has been altered from its original version by the Cryptomator team.
+ * For a detailed history of modifications, please refer to the version control log.
+ *
+ * The original file can be found at https://github.com/davemorrissey/subsampling-scale-image-view
+ *
+ * --
+ *
+ * https://cryptomator.org/
+ */
+
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,4 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-allprojects {
-    repositories {
-        mavenCentral()
-        jcenter()
-        google()
-    }
-}
-
 buildscript {
     repositories {
         mavenCentral()
@@ -15,5 +7,13 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'
+    }
+}
+
+allprojects {
+    repositories {
+        mavenCentral()
+        jcenter()
+        google()
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,9 +5,11 @@ buildscript {
         jcenter()
         google()
     }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
-    }
+}
+
+plugins {
+    id 'com.android.library' version '7.4.1' apply false
+    id 'com.android.application' version '7.4.1' apply false
 }
 
 allprojects {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,3 +1,14 @@
+# ** Notice of Modification **
+#
+# This file has been altered from its original version by the Cryptomator team.
+# For a detailed history of modifications, please refer to the version control log.
+#
+# The original file can be found at https://github.com/davemorrissey/subsampling-scale-image-view
+#
+# --
+#
+# https://cryptomator.org/
+#
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk11

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,3 +1,16 @@
+/*
+ * ** Notice of Modification **
+ *
+ * This file has been altered from its original version by the Cryptomator team.
+ * For a detailed history of modifications, please refer to the version control log.
+ *
+ * The original file can be found at https://github.com/davemorrissey/subsampling-scale-image-view
+ *
+ * --
+ *
+ * https://cryptomator.org/
+ */
+
 apply plugin: 'com.android.library'
 
 group = 'com.davemorrissey.labs'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 group = 'com.davemorrissey.labs'
 archivesBaseName = 'subsampling-scale-image-view-androidx'
-version = '3.10.0'
+version = '3.10.1-dev.0001'
 
 android {
     compileSdkVersion 33

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -33,3 +33,5 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.4.0'
     implementation 'androidx.exifinterface:exifinterface:1.3.3'
 }
+
+apply from: rootProject.file('release.gradle')

--- a/library/src/main/java/com/davemorrissey/labs/subscaleview/SubsamplingScaleImageView.java
+++ b/library/src/main/java/com/davemorrissey/labs/subscaleview/SubsamplingScaleImageView.java
@@ -1,3 +1,16 @@
+/*
+ * ** Notice of Modification **
+ *
+ * This file has been altered from its original version by the Cryptomator team.
+ * For a detailed history of modifications, please refer to the version control log.
+ *
+ * The original file can be found at https://github.com/davemorrissey/subsampling-scale-image-view
+ *
+ * --
+ *
+ * https://cryptomator.org/
+ */
+
 package com.davemorrissey.labs.subscaleview;
 
 import android.content.ContentResolver;

--- a/release.gradle
+++ b/release.gradle
@@ -42,15 +42,15 @@ afterEvaluate { project ->
             */
 
             pom {
-                name = 'SubsamplingScaleImageView'
+                name = 'Fork of com.davemorrissey.labs:subsampling-scale-image-view-androidx for Cryptomator for Android'
                 packaging = 'aar'
-                description = 'Highly configurable, easily extendable deep zoom view for displaying huge images without loss of detail. Perfect for photo galleries, maps, building plans etc.'
-                url = 'https://github.com/davemorrissey/subsampling-scale-image-view'
+                description = 'Unofficial, unaffiliated and unassociated fork of https://github.com/davemorrissey/subsampling-scale-image-view for internal use in Cryptomator for Android.'
+                url = 'https://github.com/cryptomator/subsampling-scale-image-view'
 
                 scm {
-                    url = 'scm:git@github.com:davemorrissey/subsampling-scale-image-view.git'
-                    connection = 'scm:git@github.com:davemorrissey/subsampling-scale-image-view.git'
-                    developerConnection = 'scm:git@github.com:davemorrissey/subsampling-scale-image-view.git'
+                    url = 'scm:git@github.com:cryptomator/subsampling-scale-image-view.git'
+                    connection = 'scm:git@github.com:cryptomator/subsampling-scale-image-view.git'
+                    developerConnection = 'scm:git@github.com:cryptomator/subsampling-scale-image-view.git'
                 }
 
                 licenses {
@@ -63,8 +63,15 @@ afterEvaluate { project ->
 
                 developers {
                     developer {
+                        id = 'cryptomator'
+                        name = 'Cryptomator'
+                        url = 'https://cryptomator.org/'
+                        roles = ['Maintainer of this fork']
+                    }
+                    developer {
                         id = 'davemorrissey'
                         name = 'Dave Morrissey'
+                        roles = ['Maintainer of the forked repository at https://github.com/davemorrissey/subsampling-scale-image-view']
                     }
                 }
             }

--- a/release.gradle
+++ b/release.gradle
@@ -19,19 +19,25 @@ def getMavenRepositoryPassword() {
 
 afterEvaluate { project ->
 
+    /*
     signing {
         required { isReleaseBuild() && gradle.taskGraph.hasTask("uploadArchives") }
         sign configurations.archives
     }
+    */
 
     uploadArchives {
         configuration = configurations.archives
         repositories.mavenDeployer {
+            /*
             beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+            */
 
+            /*
             repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
                 authentication(userName: getMavenRepositoryUsername(), password: getMavenRepositoryPassword())
             }
+            */
 
             pom.project {
                 name 'SubsamplingScaleImageView'
@@ -63,6 +69,7 @@ afterEvaluate { project ->
         }
     }
 
+    /*
     task androidJavadocs(type: Javadoc) {
         onlyIf { gradle.taskGraph.hasTask("uploadArchives") }
         source = android.sourceSets.main.java.sourceFiles
@@ -88,5 +95,6 @@ afterEvaluate { project ->
         archives androidSourcesJar
         archives androidJavadocsJar
     }
+    */
 
 }

--- a/release.gradle
+++ b/release.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
 def isReleaseBuild() {
@@ -26,12 +26,14 @@ afterEvaluate { project ->
     }
     */
 
-    uploadArchives {
-        configuration = configurations.archives
-        repositories.mavenDeployer {
+    publishing.publications {
+
+        maven(MavenPublication) {
             /*
             beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
             */
+            from components.release
+            artifactId = project.archivesBaseName
 
             /*
             repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
@@ -39,30 +41,30 @@ afterEvaluate { project ->
             }
             */
 
-            pom.project {
-                name 'SubsamplingScaleImageView'
-                packaging 'aar'
-                description 'Highly configurable, easily extendable deep zoom view for displaying huge images without loss of detail. Perfect for photo galleries, maps, building plans etc.'
-                url 'https://github.com/davemorrissey/subsampling-scale-image-view'
+            pom {
+                name = 'SubsamplingScaleImageView'
+                packaging = 'aar'
+                description = 'Highly configurable, easily extendable deep zoom view for displaying huge images without loss of detail. Perfect for photo galleries, maps, building plans etc.'
+                url = 'https://github.com/davemorrissey/subsampling-scale-image-view'
 
                 scm {
-                    url 'scm:git@github.com:davemorrissey/subsampling-scale-image-view.git'
-                    connection 'scm:git@github.com:davemorrissey/subsampling-scale-image-view.git'
-                    developerConnection 'scm:git@github.com:davemorrissey/subsampling-scale-image-view.git'
+                    url = 'scm:git@github.com:davemorrissey/subsampling-scale-image-view.git'
+                    connection = 'scm:git@github.com:davemorrissey/subsampling-scale-image-view.git'
+                    developerConnection = 'scm:git@github.com:davemorrissey/subsampling-scale-image-view.git'
                 }
 
                 licenses {
                     license {
-                        name 'The Apache Software License, Version 2.0'
-                        url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                        distribution 'repo'
+                        name = 'The Apache Software License, Version 2.0'
+                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                        distribution = 'repo'
                     }
                 }
 
                 developers {
                     developer {
-                        id 'davemorrissey'
-                        name 'Dave Morrissey'
+                        id = 'davemorrissey'
+                        name = 'Dave Morrissey'
                     }
                 }
             }

--- a/release.gradle
+++ b/release.gradle
@@ -1,3 +1,16 @@
+/*
+ * ** Notice of Modification **
+ *
+ * This file has been altered from its original version by the Cryptomator team.
+ * For a detailed history of modifications, please refer to the version control log.
+ *
+ * The original file can be found at https://github.com/davemorrissey/subsampling-scale-image-view
+ *
+ * --
+ *
+ * https://cryptomator.org/
+ */
+
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,3 +1,16 @@
+/*
+ * ** Notice of Modification **
+ *
+ * This file has been altered from its original version by the Cryptomator team.
+ * For a detailed history of modifications, please refer to the version control log.
+ *
+ * The original file can be found at https://github.com/davemorrissey/subsampling-scale-image-view
+ *
+ * --
+ *
+ * https://cryptomator.org/
+ */
+
 apply plugin: 'com.android.application'
 
 android {

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -10,7 +10,8 @@
 <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" tools:node="remove"/>
 <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" tools:node="remove"/>
 <application android:label="@string/app.name" android:theme="@style/sampleTheme" android:icon="@mipmap/ic_launcher" android:allowBackup="false" tools:ignore="GoogleAppIndexingWarning">
-    <activity android:name=".MainActivity" android:label="@string/app.name">
+    <activity android:name=".MainActivity" android:label="@string/app.name"
+        android:exported="true">
         <intent-filter>
             <action android:name="android.intent.action.MAIN"/>
             <category android:name="android.intent.category.LAUNCHER"/>

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -1,4 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ ** Notice of Modification **
+  ~
+  ~ This file has been altered from its original version by the Cryptomator team.
+  ~ For a detailed history of modifications, please refer to the version control log.
+  ~
+  ~ The original file can be found at https://github.com/davemorrissey/subsampling-scale-image-view
+  ~
+  ~ ~~
+  ~
+  ~ https://cryptomator.org/
+  -->
+
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools"
           package="com.davemorrissey.labs.subscaleview.test"

--- a/sample/src/main/res/layout/main.xml
+++ b/sample/src/main/res/layout/main.xml
@@ -1,4 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ ** Notice of Modification **
+  ~
+  ~ This file has been altered from its original version by the Cryptomator team.
+  ~ For a detailed history of modifications, please refer to the version control log.
+  ~
+  ~ The original file can be found at https://github.com/davemorrissey/subsampling-scale-image-view
+  ~
+  ~ ~~
+  ~
+  ~ https://cryptomator.org/
+  -->
+
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android" style="@style/fill">
 
     <LinearLayout android:orientation="vertical"

--- a/sample/src/main/res/values/style.xml
+++ b/sample/src/main/res/values/style.xml
@@ -1,4 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ ** Notice of Modification **
+  ~
+  ~ This file has been altered from its original version by the Cryptomator team.
+  ~ For a detailed history of modifications, please refer to the version control log.
+  ~
+  ~ The original file can be found at https://github.com/davemorrissey/subsampling-scale-image-view
+  ~
+  ~ ~~
+  ~
+  ~ https://cryptomator.org/
+  -->
+
 <resources>
 
     <style name="sampleTheme" parent="@android:style/Theme.Holo">

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,16 @@
+/*
+ * ** Notice of Modification **
+ *
+ * This file has been altered from its original version by the Cryptomator team.
+ * For a detailed history of modifications, please refer to the version control log.
+ *
+ * The original file can be found at https://github.com/davemorrissey/subsampling-scale-image-view
+ *
+ * --
+ *
+ * https://cryptomator.org/
+ */
+
 pluginManagement {
     repositories {
         google()

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,9 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
 include ':library'
 include ':sample'


### PR DESCRIPTION
This PR prepares the internal release 3.10.1-dev.0002.
Please note that all commits up to (and including) cad35faf465be7b4b23cabc56ebef93c6e028d19 are already on main. This PR serves as a way to discuss all recent changes.
Once it's approved, I will rebase the remaining changes onto main.

Release 3.10.1-dev.0001 has been retracted.